### PR TITLE
new website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_site
+.sass-cache
+.jekyll-metadata

--- a/404.html
+++ b/404.html
@@ -1,0 +1,24 @@
+---
+layout: default
+---
+
+<style type="text/css" media="screen">
+  .container {
+    margin: 10px auto;
+    max-width: 600px;
+    text-align: center;
+  }
+  h1 {
+    margin: 30px 0;
+    font-size: 4em;
+    line-height: 1;
+    letter-spacing: -1px;
+  }
+</style>
+
+<div class="container">
+  <h1>404</h1>
+
+  <p><strong>Page not found :(</strong></p>
+  <p>The requested page could not be found.</p>
+</div>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,27 @@
+source "https://rubygems.org"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> 3.6.0"
+
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "minima", "~> 2.0"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.6"
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.6.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 3)
+      safe_yaml (~> 1.0)
+    jekyll-feed (0.9.2)
+      jekyll (~> 3.3)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.15.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    minima (2.1.1)
+      jekyll (~> 3.3)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (2.2.1)
+    safe_yaml (1.0.4)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (~> 3.6.0)
+  jekyll-feed (~> 0.6)
+  minima (~> 2.0)
+  tzinfo-data
+
+BUNDLED WITH
+   1.15.4

--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,42 @@
-theme: jekyll-theme-dinky
-title: AskOmics
-description: Integration and querying of heterogenous data with RDF/SPARQL
-show_downloads: false
+# Welcome to Jekyll!
+#
+# This config file is meant for settings that affect your whole blog, values
+# which you are expected to set up once and rarely edit after that. If you find
+# yourself editing this file very often, consider using Jekyll's data files
+# feature for the data you need to update frequently.
+#
+# For technical reasons, this file is *NOT* reloaded automatically when you use
+# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 
-# Overriding these so it reads in a more sensible manner
-github:
-    is_project_page: true
-    is_user_page: false
-    repository_url: https://github.com/askomics/
+# Site settings
+# These are used to personalize your new site. If you look in the HTML files,
+# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
+# You can create any custom variable you would like, and they will be accessible
+# in the templates via {{ site.myvariable }}.
+title: AskOmics
+email: gogepp@inra.fr
+description: >- # this means to ignore newlines until "baseurl:"
+  AskOmics is a user-friendly web application for integrating 
+  and querying heterogeneous data using RDF/SPARQL.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://askomics.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+# twitter_username: notwitter
+github_username:  askomics
+
+# Build settings
+markdown: kramdown
+theme: minima
+plugins:
+  - jekyll-feed
+
+# Exclude from processing.
+# The following items will not be processed, by default. Create a custom list
+# to override the default setting.
+# exclude:
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/

--- a/_posts/2017-09-25-askomics-17.08.md
+++ b/_posts/2017-09-25-askomics-17.08.md
@@ -7,6 +7,6 @@ categories: version
 
 A new version of AskOmics is available [here](https://github.com/askomics/askomics/releases/tag/17.08)!
 
-If you use AskOmics with docker (or docker-compose), you can run a `docker pull askomics/askomics` or `docker-compose pull` to upgrade images. For other, run a `git pull` on the askomics directory
+If you use AskOmics with docker (or docker-compose), you can run a `docker pull askomics/askomics` or `docker-compose pull` to upgrade images. For other, run a `git pull && git checkout 17.08` on the askomics directory
 
 If you see a bug or if you want a functionality, help us by opening [issues](https://github.com/askomics/askomics/issues/new).

--- a/_posts/2017-09-25-askomics-17.08.md
+++ b/_posts/2017-09-25-askomics-17.08.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "AskOmics 17.08"
+date:   2017-09-25 14:13:00 +0200
+categories: version
+---
+
+A new version of AskOmics is available [here](https://github.com/askomics/askomics/releases/tag/17.08)!
+
+If you use AskOmics with docker (or docker-compose), you can run a `docker pull askomics/askomics` or `docker-compose pull` to upgrade images. For other, run a `git pull` on the askomics directory
+
+If you see a bug or if you want a functionality, help us by opening [issues](https://github.com/askomics/askomics/issues/new).

--- a/_posts/2017-09-25-new_website.md
+++ b/_posts/2017-09-25-new_website.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "Welcome to AskOmics website"
+date:   2017-09-25 12:07:41 +0200
+categories: news
+---
+
+Hello! this is the new AskOmics website.
+
+This website contain information about the AskOmics project; where to download it, and how install and use it. It also provide news about the AskOmics project.
+
+

--- a/about.md
+++ b/about.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: About
+permalink: /about/
+order: 4
+---
+
+
+AskOmics is a user-friendly web application for integrating and querying heterogeneous data using RDF/SPARQL.
+
+You can find the askomics source code [here](https://github.com/askomics/askomics).
+
+Other project of the askomics organisation can be found [here](https://github.com/askomics).

--- a/about.md
+++ b/about.md
@@ -11,3 +11,14 @@ AskOmics is a user-friendly web application for integrating and querying heterog
 You can find the askomics source code [here](https://github.com/askomics/askomics).
 
 Other project of the askomics organisation can be found [here](https://github.com/askomics).
+
+
+AskOmics is currently maintained by the AskoTeam (in alphabetical order):
+
+- [Anthony Bretaudeau](https://github.com/abretaud)
+- Olivier Dameron
+- [Olivier Filangi](https://github.com/ofilangi)
+- [Xavier Garnier](https://github.com/xgaia)
+- Fabrice Legeai
+
+Don’t hesitate to write us for any information about AskOmics.

--- a/doc.md
+++ b/doc.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Documentation
+permalink: /doc/
+order: 3
+---
+

--- a/doc.md
+++ b/doc.md
@@ -5,3 +5,83 @@ permalink: /doc/
 order: 3
 ---
 
+## Manual installation
+
+### Install dependencies
+
+AskOmics needs python3.4 or higher, python3-venv, nodejs and npm.
+
+
+### Download AskOmics
+
+#### Stable version
+
+Download the latest stable version of AskOmics [here](https://github.com/askomics/askomics/releases) or clone the AskOmics repository, and checkout the version manually
+
+```bash
+git clone https://github.com/askomics/askomics.git
+cd askomics
+git checkout 17.08
+```
+
+
+#### Development version
+
+Clone the repository. The `master` branch contain the latest commits.
+
+```bash
+git clone https://github.com/askomics/askomics.git
+```
+
+### Download and install a triplestore
+
+AskOmics can use the following triplestores:
+
+- Virtuoso
+- Allegrograph
+- Corese
+- RDF4j
+- Fuseki
+
+
+We advise you to use virtuoso.
+
+
+### Run AskOmics
+
+Run askomics using the `startAskomics.sh` script. This script will install all python dependencies into a virtual environment, and install all npm dependencies in the askomics directory.
+
+The script take some options:
+
+```bash
+./startAskomics.sh -t <triplestore> -d <deployment_mode>
+```
+
+With \<triplestore\>, the used triplesore, and \<deployment mode\>: dev or prod. default is prod.
+
+
+## Installation with docker-compose
+
+### Dependencies
+
+You will need docker and docker-compose. Installation instruction are [here](https://docs.docker.com/engine/installation/)
+
+### Installation
+
+Clone the askomics-docker-compose repository
+
+```bash
+git clone https://github.com/askomics/askomics-docker-compose.git
+```
+
+
+The askomics-docker-compose directory contain subdirectories. Choose one in function of what you need and run the command `docker-compose up`.
+
+For example, for askomics + virtuoso + nginx + postfix, run
+
+```bash
+cd askomics-docker-compose/virtuoso
+docker-compose up
+```
+
+AskOmics is now available at [http://localhost/askomics](http://localhost/askomics)

--- a/download.md
+++ b/download.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Download
+permalink: /download/
+order: 2
+---
+
+- [17.08](https://github.com/askomics/askomics/releases/tag/17.08)

--- a/index.md
+++ b/index.md
@@ -1,15 +1,3 @@
-## AskOmics
-
-A user-friendly web application for integrating and querying heterogeneous data using RDF/SPARQL.
-
-### Authors & Contact
-
-AskOmics is currently maintained by the AskoTeam (in alphabetical order):
-
-- Anthony Bretaudeau
-- Olivier Dameron
-- Olivier Filangi
-- Xavier Garnier
-- Fabrice Legeai
-
-Don't hesitate to [write us](mailto:gogepp@inra.fr) for any information about AskOmics.
+---
+layout: home
+---


### PR DESCRIPTION
New AskOmics website with some static pages (doc, about ...) and a section with articles to announce new versions of AskOmics and other news about the project.

Website available at [https://askomics.github.io](https://askomics.github.io)